### PR TITLE
Restore CSV export

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -12,7 +12,7 @@ class LibrariesController < ApplicationController
       format.html
       format.json
       format.drupal_xml
-      format.csv { render text: LegacySpreadsheetParser.generate(@libraries.select { |x| params[:ids].blank? || params[:ids].include?(x.id.to_s) }, @range) }
+      format.csv { render plain: LegacySpreadsheetParser.generate(@libraries.select { |x| params[:ids].blank? || params[:ids].include?(x.id.to_s) }, @range) }
     end
   end
 

--- a/spec/controllers/libraries_controller_spec.rb
+++ b/spec/controllers/libraries_controller_spec.rb
@@ -98,6 +98,13 @@ RSpec.describe LibrariesController, type: :controller do
         expect(assigns(:range)).to eq(Date.parse('2015-02-03')..Date.parse('2015-02-03'))
       end
     end
+
+    describe 'format' do
+      it 'exports a CSV' do
+        get :index, params: { format: :csv }, session: valid_session
+        expect(response.status).to eq 200
+      end
+    end
   end
 
   describe 'GET #hours_drupal' do


### PR DESCRIPTION
Fixes #69
`render :text` was replaced with `render :plain` in Rails 5.1. 
https://stackoverflow.com/questions/43428991/what-to-use-instead-of-render-text-and-render-nothing-true-in-rails-5-1