### PR TITLE
Add the 'dependent: :destroy' option to the Library class' has_one…

### DIFF
--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,5 +1,5 @@
 class Library < ActiveRecord::Base
-  has_one :node_mapping, as: :mapped
+  has_one :node_mapping, as: :mapped, dependent: :destroy
   delegate :node_id, to: :node_mapping
   has_many :locations
   accepts_nested_attributes_for :locations


### PR DESCRIPTION
…node_mapping association.

This addresses a foreign key constraint issue.