### PR TITLE
Tweak the page title formatting

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
     <!--[if IEMobile]> <meta http-equiv="cleartype" content="on"> <![endif]-->
 
-    <%= title site: 'Library Hours' %>
+    <%= title site: 'Library Hours', separator: '|', reverse: true %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <link href="https://www-media.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">


### PR DESCRIPTION
Before:
`Library Hours Green Library - Info Center`

After:
`Green Library - Info Center | Library Hours`

🤷‍♂️ 