### PR TITLE
Use the same groups everywhere

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,0 @@
-super_admin_groups:
-  - group

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,0 @@
-super_admin_groups:
-  - super-admin
-
-site_admin_groups:
-  - site-admin

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,11 +7,11 @@ FactoryBot.define do
 
   factory :superadmin_user, class: User do
     id { 'test-super-admin' }
-    ldap_groups { ['super-admin'] }
+    ldap_groups { Settings.super_admin_groups }
   end
 
   factory :site_admin_user, class: User do
     id { 'test-admin' }
-    ldap_groups { ['site-admin'] }
+    ldap_groups { Settings.site_admin_groups }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe User do
+RSpec.describe User do
   describe '.from_env' do
     subject { User.from_env('REMOTE_USER' => 'jstanford', 'WEBAUTH_LDAPPRIVGROUP' => 'admin|user') }
     it 'extracts user information from the given environment' do


### PR DESCRIPTION
This makes it easier to reason about which groups are to be set to get the needed permissions