### PR TITLE
Update styling for brand alignment

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,5 +1,7 @@
 #main-container {
   a {
+    color: $color-dark-red;
+
     &.disabled {
       color: #ccc;
       cursor: not-allowed;

--- a/app/assets/stylesheets/library_hours.scss
+++ b/app/assets/stylesheets/library_hours.scss
@@ -9,19 +9,20 @@
 .date-range {
   background-color: $well-bg;
 
+  .date-input .form-control:focus {
+    border-color: $color-digital-blue-dark;
+    box-shadow: none;
+  }
+
   @include media-breakpoint-up(sm) {
     .date-input {
       padding-right: ($spacer * .75);
-      .form-control:focus {
-        border-color: $color-digital-blue-dark;
-        box-shadow: none;
-      }
     }
   }
 
   h2 {
     padding: 0 $spacer;
-    font-size: 22px;
+    font-size: 1.375rem;
   }
 
   @include media-breakpoint-down(xs) {

--- a/app/assets/stylesheets/library_hours.scss
+++ b/app/assets/stylesheets/library_hours.scss
@@ -12,15 +12,20 @@
   @include media-breakpoint-up(sm) {
     .date-input {
       padding-right: ($spacer * .75);
+      .form-control:focus {
+        border-color: $color-digital-blue-dark;
+        box-shadow: none;
+      }
     }
   }
 
-  h4 {
+  h2 {
     padding: 0 $spacer;
+    font-size: 22px;
   }
 
   @include media-breakpoint-down(xs) {
-    h4 {
+    h2 {
       // same ps py-2 in BS4
       padding: 0 ($spacer * .5);
     }
@@ -31,8 +36,12 @@
    }
 }
 
+.btn-outline-secondary {
+  color: $color-black;
+}
+
 .closed {
-  color: #dd2121;
+  color: $color-light-red;
 }
 
 .open-24h {

--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -3,12 +3,16 @@
 //   https://github.com/sul-dlss/sul_styles/blob/master/app/assets/stylesheets/sul-styles/su_web_colors.scss
 //   https://github.com/sul-dlss/sul_styles/blob/master/app/assets/stylesheets/sul-styles/su_primary_colors.scss
 $color-cardinal-red: #8c1515;
+$color-digital-red: #B1040E;
 $color-dark-red: #820000;
+$color-light-red: #E50808;
 $color-gray: #3f3c30;
-// $color-black: #000;
-// $color-beige-40: #d5d0c0;
+$color-black: #2E2D29;
 $color-beige-30: #e3dfd5;
 $color-beige-20: #e9e6df;
 $color-beige-10: #f2f1eb;
 $color-beige-05: #fbfbf9;
-// $color-pantone-401: #b6b1a9;
+$color-white: #ffffff;
+$color-fog-light: #f4f4f4;
+$color-digital-blue: #006CB8;
+$color-digital-blue-dark: #00548f;

--- a/app/assets/stylesheets/sul-footer.scss
+++ b/app/assets/stylesheets/sul-footer.scss
@@ -67,7 +67,7 @@ $sul-footer-height: 80px;
     vertical-align: middle;
 
     @include media-breakpoint-up(xl) {
-      padding-left: 45px;
+      padding-left: 2.8125rem;
     }
   }
 }
@@ -99,25 +99,27 @@ $sul-footer-height: 80px;
     }
 
     @include media-breakpoint-up(lg) {
-      li a {
-        font-size: 17px;
-      }
+      font-size: 1.0625rem;
     }
   }
 
   .policy-links li a {
     @include media-breakpoint-up(md) {
-      font-size: 14px;
+      font-size: 0.875rem;
       font-weight: 300;
+    }
+
+    @include media-breakpoint-up(lg) {
+      font-size: 0.9375rem;
     }
   }
 
   .copyright {
-    font-size: 13px;
+    font-size: 0.85rem;
     font-weight: 300;
 
     @include media-breakpoint-up(sm) {
-      font-size: 14px;
+      font-size: 0.875rem;
       font-weight: 300;
     }
 

--- a/app/assets/stylesheets/sul-footer.scss
+++ b/app/assets/stylesheets/sul-footer.scss
@@ -1,27 +1,13 @@
-$stanford-footer-height: 250px;
-$stanford-footer-md-height: 140px;
 $sul-footer-height: 80px;
 
 #su-content {
-  padding-bottom: $stanford-footer-height + $sul-footer-height !important;
-
-  @media (min-width: 768px) {
-    padding-bottom: $stanford-footer-md-height + $sul-footer-height !important;
-  }
+  padding-bottom: 6rem;
 }
 
 #sul-footer-container {
   background-color: $sul-footer-bg-color;
   box-shadow: inset 0 4px 8px -8px $sul-shadow-color;
   clear: both;
-  margin-top: -1 * ($stanford-footer-height + $sul-footer-height);
-  min-height: $stanford-footer-height + $sul-footer-height;
-
-  @media (min-width: 768px) {
-    margin-top: -1 * ($stanford-footer-md-height + $sul-footer-height);
-    min-height: $stanford-footer-md-height + $sul-footer-height;
-  }
-
   padding: 0;
   position: relative;
 }
@@ -44,6 +30,10 @@ $sul-footer-height: 80px;
 	text-align: left;
 	padding-left: 15px;
 	font-size: small;
+
+  a {
+    color: $color-digital-blue;
+  }
 }
 
 #sul-footer {
@@ -75,14 +65,64 @@ $sul-footer-height: 80px;
     padding-left: 15px;
     text-align: left;
     vertical-align: middle;
+
+    @include media-breakpoint-up(xl) {
+      padding-left: 45px;
+    }
   }
 }
 
-#global-footer {max-width: 100%;}
-#global-footer p {max-width: 100%; width: auto;}
-#global-footer #bottom-text {margin-right: 6px;}
-#global-footer {
-  .vcard {
-    margin-left: 2rem;
+.global-footer {
+  background-color: $brand-primary;
+  color: $color-white;
+
+  a {
+    color: $color-white;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ul {
+    padding-inline-start: 0;
+    list-style: none;
+
+    @include media-breakpoint-up(lg) {
+      justify-content: flex-start !important;
+    }
+  }
+
+  li a {
+    @include media-breakpoint-up(md) {
+      font-weight: 500;
+    }
+
+    @include media-breakpoint-up(lg) {
+      li a {
+        font-size: 17px;
+      }
+    }
+  }
+
+  .policy-links li a {
+    @include media-breakpoint-up(md) {
+      font-size: 14px;
+      font-weight: 300;
+    }
+  }
+
+  .copyright {
+    font-size: 13px;
+    font-weight: 300;
+
+    @include media-breakpoint-up(sm) {
+      font-size: 14px;
+      font-weight: 300;
+    }
+
+    @include media-breakpoint-up(lg) {
+      text-align: left !important;
+    }
   }
 }

--- a/app/assets/stylesheets/top-navbar.scss
+++ b/app/assets/stylesheets/top-navbar.scss
@@ -12,13 +12,8 @@
     height: $top-nav-bar-height;
   }
 
-  a {
-    padding: 3px;
-    border-bottom: 3px solid transparent;
-    &:hover {
-      text-decoration: none;
-      border-bottom: 3px solid $brand-primary;
-    }
+  a:hover {
+    text-underline-position: under;
   }
 }
 

--- a/app/assets/stylesheets/top-navbar.scss
+++ b/app/assets/stylesheets/top-navbar.scss
@@ -11,6 +11,15 @@
     display: flex;
     height: $top-nav-bar-height;
   }
+
+  a {
+    padding: 3px;
+    border-bottom: 3px solid transparent;
+    &:hover {
+      text-decoration: none;
+      border-bottom: 3px solid $brand-primary;
+    }
+  }
 }
 
 #topnav-container {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,4 +1,4 @@
-$sul-footer-bg-color: $color-beige-10;
+$sul-footer-bg-color: $color-fog-light;
 
 $gray-base: #000;
 $gray-dark: lighten($gray-base, 20%);
@@ -23,10 +23,9 @@ $btn-default-color: $color-gray;
 $btn-default-bg: $color-beige-10;
 $btn-default-border: $color-beige-30;
 
-$link-color: #a26624;
-$link-hover-color: #a26624;
-$link-hover-decoration: none;
-$sul-link-color-border: #a26624;
+$link-color: $color-cardinal-red;
+$link-hover-color: $color-cardinal-red;
+$sul-link-color-border: $color-cardinal-red;
 
 $font-size-h1: floor(($font-size-base * 2.986));
 $font-size-h2: floor(($font-size-base * 2.074));
@@ -34,17 +33,16 @@ $font-size-h3: floor(($font-size-base * 1.728));
 $font-size-h4: floor(($font-size-base * 1.2));
 $headings-font-weight: 100;
 
-$body-bg: $color-beige-05;
+$body-bg: $color-white;
 $font-family-sans-serif: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
 $txt-color: $gray-base;
 
 $gray-41-percent: #696969;
-$sul-focus-outline: #eaab00;
+$sul-focus-outline: $color-digital-blue-dark;
 
 $navbar-default-link-color: $color-cardinal-red;
 
-$well-bg: $color-beige-10;
-$well-border: $color-beige-20;
+$well-bg: $color-fog-light;
 $well-link: $dark-orange;
 
 $breadcrumb-active-color: inherit;

--- a/app/views/libraries/_range.html.erb
+++ b/app/views/libraries/_range.html.erb
@@ -5,7 +5,7 @@
         <span class="fas fa-arrow-left" aria-hidden="true"></span>
         <span class="sr-only">Previous</span>
       <% end %>
-      <h4 class="font-weight-light mb-0"><%= l(@range.begin, format: :short) %> – <%= l(@range.end, format: :short) %></h4>
+      <h2 class="font-weight-light mb-0"><%= l(@range.begin, format: :short) %> – <%= l(@range.end, format: :short) %></h2>
       <%= link_to params.to_unsafe_h.merge(week: (@range.begin + 1.week + 1.day).strftime("%GW%V")) do %>
         <span class="fas fa-arrow-right" aria-hidden="true"></span>
         <span class="sr-only">Next</span>

--- a/app/views/shared/_global_footer.html.erb
+++ b/app/views/shared/_global_footer.html.erb
@@ -1,32 +1,41 @@
 <!-- Global footer snippet start -->
-<div id="global-footer" role="contentinfo">
-  <div class="container">
-    <div class="row">
-      <div id="bottom-logo" class="col-sm-2">
+<div class="global-footer pt-4" role="contentinfo">
+  <div class="container pt-1 pb-4">
+    <div class="row justify-content-between">
+      <div id="bottom-logo" class="col-lg-2 text-center mt-1 mb-3">
         <a href="https://www.stanford.edu">
           <img src="https://www-media.stanford.edu/su-identity/images/footer-stanford-logo@2x.png" alt="Stanford University" width="105" height="49"/>
         </a>
       </div>
       <!-- #bottom-logo end -->
-      <div id="bottom-text" class="col-sm-8">
-        <ul>
-          <li class="home"><a href="https://www.stanford.edu">Stanford Home</a></li>
-          <li class="maps alt"><a href="https://visit.stanford.edu/plan/">Maps & Directions</a></li>
-          <li class="search-stanford"><a href="https://www.stanford.edu/search/">Search Stanford</a></li>
-          <li class="emergency alt"><a href="https://emergency.stanford.edu">Emergency Info</a></li>
-        </ul>
-        <ul id="policy-links">
-          <li><a href="https://www.stanford.edu/site/terms/" title="Terms of use for sites">Terms of Use</a></li>
-          <li><a href="https://www.stanford.edu/site/privacy/" title="Privacy and cookie policy">Privacy</a></li>
-          <li><a href="https://uit.stanford.edu/security/copyright-infringement" title="Report alleged copyright infringement">Copyright</a></li>
-          <li><a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="Ownership and use of Stanford trademarks and images">Trademarks</a></li>
-          <li><a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="Non-discrimination policy">Non-Discrimination</a></li>
-          <li><a href="https://www.stanford.edu/site/accessibility" title="Report web accessibility issues">Accessibility</a></li>
-        </ul>
-      </div> <!-- .bottom-text end -->
-      <div class="clear"></div>
-      <p class="copyright vcard offset-sm-2">&copy; <span class="fn org">Stanford University</span>, <span class="adr"> <span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.
-      </p>
+      <div class="col-12 col-lg-10">
+        <nav class="d-flex justify-content-center mb-2">
+          <div class="row">
+            <div class="col-6 col-md-12">
+              <ul class="global-footer-menu d-flex flex-column flex-md-row justify-content-center text-nowrap mb-1">
+                <li class="home mr-sm-3 mr-lg-4 mb-1"><a href="https://www.stanford.edu">Stanford Home</a></li>
+                <li class="maps alt mr-sm-3 mr-lg-4 mb-1"><a href="https://visit.stanford.edu/plan/">Maps & Directions</a></li>
+                <li class="search-stanford mr-sm-3 mr-lg-4 mb-1"><a href="https://www.stanford.edu/search/">Search Stanford</a></li>
+                <li class="emergency alt mr-sm-3 mr-lg-4"><a href="https://emergency.stanford.edu">Emergency Info</a></li>
+              </ul>
+            </div>
+            <div class="col-6 col-md-12">
+              <ul class="global-footer-menu policy-links d-flex flex-column flex-md-row justify-content-center text-nowrap mb-1">
+                <li class="mr-sm-3 mr-lg-4 mb-1"><a href="https://www.stanford.edu/site/terms/" title="Terms of use for sites">Terms of Use</a></li>
+                <li class="mr-sm-3 mr-lg-4 mb-1"><a href="https://www.stanford.edu/site/privacy/" title="Privacy and cookie policy">Privacy</a></li>
+                <li class="mr-sm-3 mr-lg-4 mb-1"><a href="https://uit.stanford.edu/security/copyright-infringement" title="Report alleged copyright infringement">Copyright</a></li>
+                <li class="mr-sm-3 mr-lg-4 mb-1"><a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="Ownership and use of Stanford trademarks and images">Trademarks</a></li>
+                <li class="mr-sm-3 mr-lg-4"><a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="Non-discrimination policy">Non-Discrimination</a></li>
+                <li><a href="https://www.stanford.edu/site/accessibility" title="Report web accessibility issues">Accessibility</a></li>
+              </ul>
+            </div>
+          </div>
+        </nav>
+        <div class="copyright text-center lg:text-left">
+          <p>&copy; <span class="fn org">Stanford University</span>, <span class="adr"> <span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.
+          </p>
+        </div>
+      </div>
     </div> <!-- .row end -->
   </div> <!-- .container end -->
 </div> <!-- global-footer end -->


### PR DESCRIPTION
Looking at addressing #518.

* Attempted to use more identity colors where possible. There are some cases where it might be more appropriate to use a dramatically different color, but I didn't want to deviate too far from the existing design without input (e.g., switching to blue for the main links).
* Switched to some higher contrast colors for accessibility.
* One header tag was out of ascending order and was getting flagged.
* Made the footer more responsive in the style of the identity site/main library site. If this is out of scope for this issue I can roll this back.

Example (cut out the middle):

![Screenshot 2024-03-14 at 5 13 30 PM](https://github.com/sul-dlss/library_hours_rails/assets/4421877/a6784ae1-bbef-4864-9eb6-5db5a73cfa9b)

![Screenshot 2024-03-14 at 5 13 50 PM](https://github.com/sul-dlss/library_hours_rails/assets/4421877/2f2e6192-74a6-4b81-b567-b318080830c8)

Keeping as draft for now. I've tested locally, but if this is on the right track I'd want to deploy the branch and test more thoroughly.
