### PR TITLE
Unpin turbo-rails and update to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,4 @@ gem 'rack-attack'
 gem "cssbundling-rails", "~> 1.1"
 gem "importmap-rails", "~> 2.0"
 gem "stimulus-rails", "~> 1.2"
-gem "turbo-rails", "~> 1.4.0" # Pinned until https://github.com/hotwired/turbo-rails/pull/504 is merged/released
+gem "turbo-rails", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,7 +372,7 @@ GEM
     timeout (0.4.1)
     tophat (2.3.1)
       actionpack (>= 3.0.0)
-    turbo-rails (1.4.0)
+    turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -438,7 +438,7 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   stimulus-rails (~> 1.2)
   tophat
-  turbo-rails (~> 1.4.0)
+  turbo-rails (~> 2.0)
   web-console (>= 4.1)
 
 BUNDLED WITH


### PR DESCRIPTION
https://github.com/hotwired/turbo-rails/pull/504 has been merged and released so we can unpin turbo-rails and update to the latest version.