### PR TITLE
Put min/max values for allowed date ranges.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,5 +38,7 @@ class ApplicationController < ActionController::Base
     @range ||= Time.zone.now.beginning_of_week(:sunday).to_date..(Time.zone.now.beginning_of_week(:sunday) + 6.days).to_date
 
     @range.tap { |range| raise ActionController::BadRequest, 'Requested range is too big' if range.first + 18.months < range.last }
+    @range.tap { |range| raise ActionController::BadRequest, 'Requested range is too old' if range.first.before? 48.months.ago }
+    @range.tap { |range| raise ActionController::BadRequest, 'Requested range is too new' if range.last.after? 24.months.from_now }
   end
 end

--- a/app/views/libraries/_range.html.erb
+++ b/app/views/libraries/_range.html.erb
@@ -4,12 +4,12 @@
       <%= link_to params.to_unsafe_h.merge(week: (@range.begin - 1.week + 1.day).strftime("%GW%V")) do %>
         <span class="fas fa-arrow-left" aria-hidden="true"></span>
         <span class="sr-only">Previous</span>
-      <% end %>
+      <% end unless @range.begin.before?(24.months.ago)%>
       <h4 class="font-weight-light mb-0"><%= l(@range.begin, format: :short) %> – <%= l(@range.end, format: :short) %></h4>
       <%= link_to params.to_unsafe_h.merge(week: (@range.begin + 1.week + 1.day).strftime("%GW%V")) do %>
         <span class="fas fa-arrow-right" aria-hidden="true"></span>
         <span class="sr-only">Next</span>
-      <% end %>
+      <% end unless @range.end.after?(18.months.from_now) %>
     </div>
 
     <div class="col-lg-6 col-xs-12">

--- a/spec/controllers/libraries_controller_spec.rb
+++ b/spec/controllers/libraries_controller_spec.rb
@@ -75,39 +75,52 @@ RSpec.describe LibrariesController, type: :controller do
     end
 
     describe '@range' do
+      let(:year) { Time.zone.now.year }
       it 'defaults to the current week' do
         get :index, params: {}, session: valid_session
         expect(assigns(:range)).to eq(Time.zone.today.beginning_of_week(:sunday).to_date..(Time.zone.today.end_of_week(:sunday).to_date))
       end
 
       it 'assigns using the given week' do
-        get :index, params: { week: '2015W1' }, session: valid_session
-        expect(assigns(:range)).to eq(Calendar.week('2015W1'))
+        get :index, params: { week: "#{year}W1" }, session: valid_session
+        expect(assigns(:range)).to eq(Calendar.week("#{year}W1"))
       end
 
       it 'assigns using the given time' do
-        get :index, params: { when: '2015-04-05' }, session: valid_session
-        expect(assigns(:range)).to eq(Date.parse('2015-04-05')..Date.parse('2015-04-05'))
+        get :index, params: { when: "#{year}-04-05" }, session: valid_session
+        expect(assigns(:range)).to eq(Date.parse("#{year}-04-05")..Date.parse("#{year}-04-05"))
       end
 
       it 'assigns using from/to' do
-        get :index, params: { from: '2015-02-03', to: '2015-03-02' }, session: valid_session
-        expect(assigns(:range)).to eq(Date.parse('2015-02-03')..Date.parse('2015-03-02'))
+        get :index, params: { from: "#{year}-02-03", to: "#{year}-03-02" }, session: valid_session
+        expect(assigns(:range)).to eq(Date.parse("#{year}-02-03")..Date.parse("#{year}-03-02"))
       end
 
       it 'assigns using from' do
-        get :index, params: { from: '2015-02-03' }, session: valid_session
-        expect(assigns(:range)).to eq(Date.parse('2015-02-03')..Date.parse('2015-02-03'))
+        get :index, params: { from: "#{year}-02-03" }, session: valid_session
+        expect(assigns(:range)).to eq(Date.parse("#{year}-02-03")..Date.parse("#{year}-02-03"))
       end
 
       it 'assigns using from' do
-        get :index, params: { date: '2022-09-18' }, session: valid_session
-        expect(subject).to redirect_to 'http://test.host/?week=2022W38'
+        get :index, params: { date: "#{year}-09-18" }, session: valid_session
+        expect(subject).to redirect_to "http://test.host/?week=#{year}W38"
       end
 
       it 'restricts the range to an 18 month period' do
         expect do
-          get :index, params: { from: '2015-02-03', to: '2020-03-02' }, session: valid_session
+          get :index, params: { from: "#{year}-02-03", to: "#{year+4}-03-02" }, session: valid_session
+        end.to raise_error(ActionController::BadRequest)
+      end
+
+      it 'restricts the beginning of the range to an 48 month period' do
+        expect do
+          get :index, params: { from: "#{year-5}-02-03", to: "#{year-5}-03-02" }, session: valid_session
+        end.to raise_error(ActionController::BadRequest)
+      end
+
+      it 'restricts the end of the range to an 24 month period' do
+        expect do
+          get :index, params: { from: "#{year+3}-02-03", to: "#{year+3}-03-02" }, session: valid_session
         end.to raise_error(ActionController::BadRequest)
       end
     end


### PR DESCRIPTION
We've got crawlers trying to find hours from 1970 or 2081... maybe they shouldn't.