### PR TITLE
More Bootstrap 5 adjustments

### DIFF
--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -1,8 +1,6 @@
 <% url = calendar.persisted? ? library_location_calendar_path(calendar.library, calendar.location, calendar) : library_location_calendars_path(calendar.location.library, calendar.location, day: calendar.date) %>
 
-<%= form_with model: calendar,
-    url: url,
-    class: 'form-inline' do |f| %>
+<%= form_with model: calendar, url: url do |f| %>
   <% if f.object.errors.any? %>
     <p class="alert alert-danger"><%= to_sentence f.object.errors.full_messages %></p>
   <% end %>

--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -4,7 +4,7 @@
       Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
       <%= hidden_field_tag :url, request.referer, class: 'reporting-from-field' %>
     </div>
-    <div class="col-sm-3 text-right">
+    <div class="col-sm-3 text-end">
       <%= link_to 'Check system status', 'http://library-status.stanford.edu', class: 'alert-link' %>
     </div>
   </div>

--- a/app/views/term_hours/_form.html.erb
+++ b/app/views/term_hours/_form.html.erb
@@ -1,8 +1,6 @@
 <% url = term_hour.persisted? ? library_location_term_hour_path(term_hour.location.library_id, term_hour.location, term_hour, day_of_week: params[:day_of_week]) : library_location_term_hours_path(term_hour.location.library_id, term_hour.location, term_id: term_hour.term_id, day_of_week: params[:day_of_week]) %>
 
-<%= form_with model: term_hour, 
-    url: url,
-    class: 'form-inline' do |f| %>
+<%= form_with model: term_hour, url: url do |f| %>
   <% if f.object.errors.any? %>
     <p class="alert alert-danger"><%= to_sentence f.object.errors.full_messages %></p>
   <% end %>


### PR DESCRIPTION
`text-right` => `text-end`

Before:
<img width="763" alt="Screenshot 2024-08-23 at 9 44 52 AM" src="https://github.com/user-attachments/assets/340ba798-5822-4eed-b4bd-7080ab3c6477">

After:
<img width="784" alt="Screenshot 2024-08-23 at 9 44 48 AM" src="https://github.com/user-attachments/assets/23ca38fe-d373-4e8d-915a-de97db984ab6">

Remove `form-inline`; `input-group` does this for us.
No change:
<img width="397" alt="Screenshot 2024-08-23 at 9 44 42 AM" src="https://github.com/user-attachments/assets/688ca5eb-c4cc-4bc5-bf63-82c75964351c">
