### PR TITLE
Restore staff login link to sul footer

### DIFF
--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -23,6 +23,9 @@
             <li class="mx-2 mx-md-3">
               <a href="https://library-status.stanford.edu/">System status</a>
             </li>
+            <li class="mx-2 mx-md-3">
+              <%= link_to "Staff login", login_path(referrer: request.original_url) %>
+            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Staff login link was previously in the SUL footer but was removed by https://github.com/sul-dlss/library_hours_rails/pull/585