### PR TITLE
Remove extra Library Hours header

### DIFF
--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -1,5 +1,4 @@
 <% breadcrumb :root %>
-<h1>Library hours</h1>
 
 <%= render 'range' %>
 <% @libraries.each do |library| %>


### PR DESCRIPTION
Fixes #591

Before:
<img width="1149" alt="Screenshot 2024-10-31 at 1 33 37 PM" src="https://github.com/user-attachments/assets/11eecec4-20bf-4b20-a30b-c4fbe5154950">
After:
<img width="1181" alt="Screenshot 2024-10-31 at 1 27 56 PM" src="https://github.com/user-attachments/assets/c5ab6a26-7c06-41dc-a165-c817dfe12c05">
