### PR TITLE
Restore holiday table cell styling; fixes #604

### DIFF
--- a/app/assets/stylesheets/library_hours.scss
+++ b/app/assets/stylesheets/library_hours.scss
@@ -71,3 +71,8 @@ th small {
 .alert-link {
   text-decoration: underline;
 }
+
+.table .holiday {
+  background-color: var(--stanford-fog-light);
+  font-weight: semi-bold;
+}


### PR DESCRIPTION
![Screenshot 2025-02-06 at 09 08 54](https://github.com/user-attachments/assets/ebe905e2-068b-4c65-82cd-ec9a2fb58598)
