### PR TITLE
fix holiday alignment on mobile views

### DIFF
--- a/app/assets/stylesheets/library_hours.css
+++ b/app/assets/stylesheets/library_hours.css
@@ -37,7 +37,7 @@ th.location-name {
 
 td.hours,
 th.hours {
-  width: 100px;
+  width: 6.25rem;
   padding: 0.5rem;
 }
 
@@ -84,6 +84,7 @@ th small {
   td.hours,
   th.hours {
     display: block;
+    width: 5rem;
   }
 
   .holiday-text {

--- a/app/views/libraries/_location_hours_mobile.html.erb
+++ b/app/views/libraries/_location_hours_mobile.html.erb
@@ -18,7 +18,7 @@
         <tr>
           <% l.hours(@range).each do |calendars| %>
             <td class="hours <%= 'exceptions' if calendars.any?(&:persisted?) %> <%= 'holiday' if Term.holiday? calendars.first.date %>" itemprop="openingHoursSpecification" itemscope itemtype="http://schema.org/OpeningHoursSpecification">
-                <div class="d-flex justify-space-between gap-5">
+              <div class="d-flex justify-space-between gap-4 <%= Term.holiday?(calendars.first.date) ? 'justify-content-center' : '' %>">
                   <div>
                     <span itemprop="validFrom" content="<%= l calendars.first.date %>" aria-hidden="true"></span>
                     <span itemprop="validThrough" content="<%= l calendars.first.date %>" aria-hidden="true"></span>
@@ -28,7 +28,7 @@
                     </span>
                   </div>
                   <% if Term.holiday? calendars.first.date %>
-                    <div class="mobile-holiday fw-semibold"><%= Term.holidays.for_date(calendars.first.date).first.name %></div>
+                    <div class="mobile-holiday fw-semibold text-truncate"><%= Term.holidays.for_date(calendars.first.date).first.name %></div>
                   <% end %>
                 </div>
               <% end %>


### PR DESCRIPTION
Before:
<img width="347" height="910" alt="Screenshot 2025-11-24 at 2 22 50 PM" src="https://github.com/user-attachments/assets/1be23d02-2535-4a10-9fd1-6bf88aebb6e8" />

After:
<img width="346" height="861" alt="Screenshot 2025-11-24 at 2 22 35 PM" src="https://github.com/user-attachments/assets/f0c0819f-a49f-4a8e-8928-238a00c024c3" />
